### PR TITLE
perf: array.includes → set.has

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@https-tls/benchmark",
+  "private": true,
+  "version": "1.0.0",
+  "devDependencies": {
+    "tinybench": "latest"
+  }
+}

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@https-tls/benchmark",
-  "private": true,
   "version": "1.0.0",
   "devDependencies": {
     "tinybench": "latest"
-  }
+  },
+  "private": true
 }

--- a/benchmark/sort-headers.mjs
+++ b/benchmark/sort-headers.mjs
@@ -1,0 +1,221 @@
+'use strict'
+
+import { Bench } from 'tinybench'
+import { readFileSync } from 'fs'
+
+import { getHeader } from '../src/headers.js'
+
+const getBrowser = () => 'chrome'
+
+const HEADERS_ORDER = JSON.parse(
+  readFileSync('../src/headers-order.json', 'utf8')
+)
+
+const headers = await fetch('https://vercel.com').then(res =>
+  Object.fromEntries(res.headers)
+)
+
+const implementations = {
+  v0: headers => {
+    const userAgent = getHeader('user-agent', headers)
+    const browser = getBrowser(userAgent)
+    const order = HEADERS_ORDER[browser] || []
+    const orderedHeaders = {}
+
+    // Pre-calculate order as a Set for O(1) lookup
+    const orderSet = new Set(order)
+    const headerKeys = Object.keys(headers)
+
+    // Single loop approach
+    let i = 0
+    const orderLength = order.length
+
+    // Add ordered headers first
+    for (; i < orderLength; i++) {
+      const key = order[i]
+      if (key in headers) {
+        orderedHeaders[key] = headers[key]
+      }
+    }
+
+    // Add remaining unordered headers
+    const headersLength = headerKeys.length
+    for (i = 0; i < headersLength; i++) {
+      const key = headerKeys[i]
+      if (!orderSet.has(key)) {
+        orderedHeaders[key] = headers[key]
+      }
+    }
+
+    return orderedHeaders
+  },
+  v1: headers => {
+    const userAgent = getHeader('user-agent', headers)
+    const browser = getBrowser(userAgent)
+    const order = HEADERS_ORDER[browser] || []
+    const orderedHeaders = {}
+
+    // Cache length and use local variables
+    const orderLength = order.length
+    let key
+    let i = 0
+
+    // Add ordered headers first
+    for (; i < orderLength; i++) {
+      key = order[i]
+      if (key in headers) {
+        orderedHeaders[key] = headers[key]
+      }
+    }
+
+    // Add remaining headers
+    const headerKeys = Object.keys(headers)
+    const headersLength = headerKeys.length
+    const orderSet = new Set(order) // Use Set for O(1) lookup
+
+    for (i = 0; i < headersLength; i++) {
+      key = headerKeys[i]
+      if (!orderSet.has(key)) {
+        orderedHeaders[key] = headers[key]
+      }
+    }
+
+    return orderedHeaders
+  },
+  v2: headers => {
+    const userAgent = getHeader('user-agent', headers)
+    const browser = getBrowser(userAgent)
+    const order = HEADERS_ORDER[browser] || []
+    const orderedHeaders = {}
+
+    // Create lookup object instead of using includes
+    const orderLookup = {}
+    let i = 0
+    const orderLength = order.length
+
+    for (; i < orderLength; i++) {
+      orderLookup[order[i]] = true
+    }
+
+    // Add ordered headers first
+    for (i = 0; i < orderLength; i++) {
+      const key = order[i]
+      if (key in headers) {
+        orderedHeaders[key] = headers[key]
+      }
+    }
+
+    // Add remaining headers
+    const headerKeys = Object.keys(headers)
+    const headersLength = headerKeys.length
+
+    for (i = 0; i < headersLength; i++) {
+      const key = headerKeys[i]
+      if (!orderLookup[key]) {
+        orderedHeaders[key] = headers[key]
+      }
+    }
+
+    return orderedHeaders
+  },
+  v3: headers => {
+    const userAgent = getHeader('user-agent', headers)
+    const browser = getBrowser(userAgent)
+    const order = HEADERS_ORDER[browser] || []
+    const orderedHeaders = {}
+
+    const orderLength = order.length
+    for (let i = 0; i < orderLength; i++) {
+      const attribute = order[i]
+      if (attribute in headers) {
+        orderedHeaders[attribute] = headers[attribute]
+      }
+    }
+
+    const headerKeys = Object.keys(headers)
+    const headersLength = headerKeys.length
+    const orderSet = new Set(order) // Use Set for O(1) lookup
+    for (let i = 0; i < headersLength; i++) {
+      const attribute = headerKeys[i]
+      if (!orderSet.has(attribute)) {
+        orderedHeaders[attribute] = headers[attribute]
+      }
+    }
+
+    return orderedHeaders
+  },
+  v4: headers => {
+    const userAgent = getHeader('user-agent', headers)
+    const browser = getBrowser(userAgent)
+    const order = HEADERS_ORDER[browser] || []
+    const orderedHeaders = {}
+
+    for (const attribute of order) {
+      if (attribute in headers) {
+        orderedHeaders[attribute] = headers[attribute]
+      }
+    }
+
+    for (const attribute of Object.keys(headers)) {
+      if (!order.includes(attribute)) {
+        orderedHeaders[attribute] = headers[attribute]
+      }
+    }
+
+    return orderedHeaders
+  },
+  v5: headers => {
+    const userAgent = getHeader('user-agent', headers)
+    const browser = getBrowser(userAgent)
+    const order = HEADERS_ORDER[browser] || []
+    const orderedHeaders = {}
+
+    // First, add ordered headers
+    for (let i = 0; i < order.length; i++) {
+      const key = order[i]
+      if (key in headers) orderedHeaders[key] = headers[key]
+    }
+
+    // Then, add remaining headers
+    const headerKeys = Object.keys(headers)
+    for (let i = 0; i < headerKeys.length; i++) {
+      const key = headerKeys[i]
+      if (!order.includes(key)) orderedHeaders[key] = headers[key]
+    }
+
+    return orderedHeaders
+  }
+}
+
+const cases = Object.entries(implementations)
+
+// Verify all implementations produce the same result
+const reference = JSON.stringify(
+  implementations[Object.keys(implementations)[0]](headers)
+)
+cases.slice(1).forEach(([name, implementation]) => {
+  const result = JSON.stringify(implementation(headers))
+  if (result !== reference) {
+    throw new Error(`Different output for ${name}: ${result}`)
+  }
+})
+
+const bench = new Bench({ time: 1000 })
+
+for (const [name, implementation] of cases) {
+  bench.add(name, () => implementation(headers))
+}
+
+await bench.run()
+
+const results = bench.tasks.map(task => ({
+  name: task.name,
+  value: task.result.latency.mean
+}))
+
+const fastest = results.reduce((prev, current) =>
+  prev.value < current.value ? prev : current
+)
+
+console.table(bench.table())
+console.log(`Fastest implementation: ${fastest.name}`)

--- a/benchmark/sort-headers.mjs
+++ b/benchmark/sort-headers.mjs
@@ -16,155 +16,7 @@ const headers = await fetch('https://vercel.com').then(res =>
 )
 
 const implementations = {
-  v0: headers => {
-    const userAgent = getHeader('user-agent', headers)
-    const browser = getBrowser(userAgent)
-    const order = HEADERS_ORDER[browser] || []
-    const orderedHeaders = {}
-
-    // Pre-calculate order as a Set for O(1) lookup
-    const orderSet = new Set(order)
-    const headerKeys = Object.keys(headers)
-
-    // Single loop approach
-    let i = 0
-    const orderLength = order.length
-
-    // Add ordered headers first
-    for (; i < orderLength; i++) {
-      const key = order[i]
-      if (key in headers) {
-        orderedHeaders[key] = headers[key]
-      }
-    }
-
-    // Add remaining unordered headers
-    const headersLength = headerKeys.length
-    for (i = 0; i < headersLength; i++) {
-      const key = headerKeys[i]
-      if (!orderSet.has(key)) {
-        orderedHeaders[key] = headers[key]
-      }
-    }
-
-    return orderedHeaders
-  },
-  v1: headers => {
-    const userAgent = getHeader('user-agent', headers)
-    const browser = getBrowser(userAgent)
-    const order = HEADERS_ORDER[browser] || []
-    const orderedHeaders = {}
-
-    // Cache length and use local variables
-    const orderLength = order.length
-    let key
-    let i = 0
-
-    // Add ordered headers first
-    for (; i < orderLength; i++) {
-      key = order[i]
-      if (key in headers) {
-        orderedHeaders[key] = headers[key]
-      }
-    }
-
-    // Add remaining headers
-    const headerKeys = Object.keys(headers)
-    const headersLength = headerKeys.length
-    const orderSet = new Set(order) // Use Set for O(1) lookup
-
-    for (i = 0; i < headersLength; i++) {
-      key = headerKeys[i]
-      if (!orderSet.has(key)) {
-        orderedHeaders[key] = headers[key]
-      }
-    }
-
-    return orderedHeaders
-  },
-  v2: headers => {
-    const userAgent = getHeader('user-agent', headers)
-    const browser = getBrowser(userAgent)
-    const order = HEADERS_ORDER[browser] || []
-    const orderedHeaders = {}
-
-    // Create lookup object instead of using includes
-    const orderLookup = {}
-    let i = 0
-    const orderLength = order.length
-
-    for (; i < orderLength; i++) {
-      orderLookup[order[i]] = true
-    }
-
-    // Add ordered headers first
-    for (i = 0; i < orderLength; i++) {
-      const key = order[i]
-      if (key in headers) {
-        orderedHeaders[key] = headers[key]
-      }
-    }
-
-    // Add remaining headers
-    const headerKeys = Object.keys(headers)
-    const headersLength = headerKeys.length
-
-    for (i = 0; i < headersLength; i++) {
-      const key = headerKeys[i]
-      if (!orderLookup[key]) {
-        orderedHeaders[key] = headers[key]
-      }
-    }
-
-    return orderedHeaders
-  },
-  v3: headers => {
-    const userAgent = getHeader('user-agent', headers)
-    const browser = getBrowser(userAgent)
-    const order = HEADERS_ORDER[browser] || []
-    const orderedHeaders = {}
-
-    const orderLength = order.length
-    for (let i = 0; i < orderLength; i++) {
-      const attribute = order[i]
-      if (attribute in headers) {
-        orderedHeaders[attribute] = headers[attribute]
-      }
-    }
-
-    const headerKeys = Object.keys(headers)
-    const headersLength = headerKeys.length
-    const orderSet = new Set(order) // Use Set for O(1) lookup
-    for (let i = 0; i < headersLength; i++) {
-      const attribute = headerKeys[i]
-      if (!orderSet.has(attribute)) {
-        orderedHeaders[attribute] = headers[attribute]
-      }
-    }
-
-    return orderedHeaders
-  },
-  v4: headers => {
-    const userAgent = getHeader('user-agent', headers)
-    const browser = getBrowser(userAgent)
-    const order = HEADERS_ORDER[browser] || []
-    const orderedHeaders = {}
-
-    for (const attribute of order) {
-      if (attribute in headers) {
-        orderedHeaders[attribute] = headers[attribute]
-      }
-    }
-
-    for (const attribute of Object.keys(headers)) {
-      if (!order.includes(attribute)) {
-        orderedHeaders[attribute] = headers[attribute]
-      }
-    }
-
-    return orderedHeaders
-  },
-  v5: headers => {
+  'v0 (for loop)': headers => {
     const userAgent = getHeader('user-agent', headers)
     const browser = getBrowser(userAgent)
     const order = HEADERS_ORDER[browser] || []
@@ -181,6 +33,34 @@ const implementations = {
     for (let i = 0; i < headerKeys.length; i++) {
       const key = headerKeys[i]
       if (!order.includes(key)) orderedHeaders[key] = headers[key]
+    }
+
+    return orderedHeaders
+  },
+  'v1 (set)': headers => {
+    const userAgent = getHeader('user-agent', headers)
+    const browser = getBrowser(userAgent)
+    const order = HEADERS_ORDER[browser] || []
+    const orderedHeaders = {}
+
+    // Pre-calculate order as a Set for O(1) lookup
+    const orderSet = new Set(order)
+    const headerKeys = Object.keys(headers)
+    const headersLength = headerKeys.length
+    const orderLength = order.length
+    let i = 0
+    let key
+
+    // Add ordered headers
+    for (; i < orderLength; i++) {
+      key = order[i]
+      if (key in headers) orderedHeaders[key] = headers[key]
+    }
+
+    // Add remaining headers
+    for (i = 0; i < headersLength; i++) {
+      key = headerKeys[i]
+      if (!orderSet.has(key)) orderedHeaders[key] = headers[key]
     }
 
     return orderedHeaders

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "signature",
     "tls"
   ],
-  "dependencies": {},
   "devDependencies": {
     "@commitlint/cli": "latest",
     "@commitlint/config-conventional": "latest",
@@ -70,6 +69,12 @@
     "test": "c8 ava"
   },
   "license": "MIT",
+  "ava": {
+    "files": [
+      "test/**/*.js",
+      "!test/helpers.js"
+    ]
+  },
   "commitlint": {
     "extends": [
       "@commitlint/config-conventional"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "lint": "standard-markdown README.md && standard",
     "postinstall": "node scripts/postinstall.js",
     "postrelease": "npm run release:tags && npm run release:github && (ci-publish || npm publish --access=public)",
-    "prerelease": "npm run update:check && npm run contributors",
+    "prerelease": "npm run contributors",
     "pretest": "npm run lint",
     "release": "standard-version -a",
     "release:github": "github-generate-release",

--- a/src/headers.js
+++ b/src/headers.js
@@ -20,20 +20,27 @@ const getHeader = (key, headers) => {
 const sortHeaders = headers => {
   const userAgent = getHeader('user-agent', headers)
   const browser = getBrowser(userAgent)
-
   const order = HEADERS_ORDER[browser] || []
   const orderedHeaders = {}
 
-  for (const attribute of order) {
-    if (attribute in headers) {
-      orderedHeaders[attribute] = headers[attribute]
-    }
+  // Pre-calculate order as a Set for O(1) lookup
+  const orderSet = new Set(order)
+  const headerKeys = Object.keys(headers)
+  const headersLength = headerKeys.length
+  const orderLength = order.length
+  let i = 0
+  let key
+
+  // Add ordered headers
+  for (; i < orderLength; i++) {
+    key = order[i]
+    if (key in headers) orderedHeaders[key] = headers[key]
   }
 
-  for (const attribute of Object.keys(headers)) {
-    if (!order.includes(attribute)) {
-      orderedHeaders[attribute] = headers[attribute]
-    }
+  // Add remaining headers
+  for (i = 0; i < headersLength; i++) {
+    key = headerKeys[i]
+    if (!orderSet.has(key)) orderedHeaders[key] = headers[key]
   }
 
   return orderedHeaders

--- a/src/headers.js
+++ b/src/headers.js
@@ -22,21 +22,21 @@ const sortHeaders = headers => {
   const browser = getBrowser(userAgent)
 
   const order = HEADERS_ORDER[browser] || []
-  const orderedSample = {}
+  const orderedHeaders = {}
 
   for (const attribute of order) {
     if (attribute in headers) {
-      orderedSample[attribute] = headers[attribute]
+      orderedHeaders[attribute] = headers[attribute]
     }
   }
 
   for (const attribute of Object.keys(headers)) {
     if (!order.includes(attribute)) {
-      orderedSample[attribute] = headers[attribute]
+      orderedHeaders[attribute] = headers[attribute]
     }
   }
 
-  return orderedSample
+  return orderedHeaders
 }
 
 module.exports = { getHeader, sortHeaders }

--- a/test/browser.js
+++ b/test/browser.js
@@ -4,10 +4,24 @@ const test = require('ava')
 
 const { getBrowser } = require('..')
 
+const { UA } = require('./helpers')
+
 test('undefined if user agent is not provided', t => {
   t.is(getBrowser(), undefined)
 })
 
 test('safari as fallback', t => {
   t.is(getBrowser('googlebot'), 'safari')
+})
+
+test('detect safari', t => {
+  t.is(getBrowser(UA.SAFARI), 'safari')
+})
+
+test('detect firefox', t => {
+  t.is(getBrowser(UA.FIREFOX), 'firefox')
+})
+
+test('detect chrome', t => {
+  t.is(getBrowser(UA.CHROME), 'chrome')
 })

--- a/test/headers.js
+++ b/test/headers.js
@@ -4,6 +4,8 @@ const test = require('ava')
 
 const { sortHeaders, getHeader } = require('..')
 
+const { UA } = require('./helpers')
+
 test('.getHeader', t => {
   t.is(getHeader('user-agent', { 'user-agent': 'googlebot' }), 'googlebot')
   t.is(getHeader('user-agent', { 'User-Agent': 'googlebot' }), 'googlebot')
@@ -11,20 +13,34 @@ test('.getHeader', t => {
 
 test('.sortHeaders', t => {
   t.deepEqual(
-    sortHeaders({ 'user-agent': undefined, referer: 'bar', accept: 'foo' }),
-    {
-      'user-agent': undefined,
+    sortHeaders({
+      'x-random': 'foo',
+      'user-agent': UA.CHROME,
       referer: 'bar',
-      accept: 'foo'
+      accept: 'foo',
+      Host: 'foo'
+    }),
+    {
+      Host: 'foo',
+      'user-agent': UA.CHROME,
+      referer: 'bar',
+      accept: 'foo',
+      'x-random': 'foo'
     }
   )
 
   t.deepEqual(
-    sortHeaders({ 'user-agent': 'safari', referer: 'bar', accept: 'foo' }),
+    sortHeaders({
+      'x-random': 'foo',
+      'user-agent': 'safari',
+      referer: 'bar',
+      accept: 'foo'
+    }),
     {
       accept: 'foo',
       referer: 'bar',
-      'user-agent': 'safari'
+      'user-agent': 'safari',
+      'x-random': 'foo'
     }
   )
 })

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,10 @@
+const UA = {
+  CHROME:
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.5993.90 Safari/537.36',
+  FIREFOX:
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:118.0) Gecko/20100101 Firefox/118.0',
+  SAFARI:
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0_0) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15'
+}
+
+module.exports = { UA }


### PR DESCRIPTION
```
node sort-headers.mjs
┌─────────┬─────────────────┬──────────────────────┬─────────────────────┬────────────────────────────┬───────────────────────────┬─────────┐
│ (index) │ Task name       │ Latency average (ns) │ Latency median (ns) │ Throughput average (ops/s) │ Throughput median (ops/s) │ Samples │
├─────────┼─────────────────┼──────────────────────┼─────────────────────┼────────────────────────────┼───────────────────────────┼─────────┤
│ 0       │ 'v0 (for loop)' │ '4414.58 ± 0.33%'    │ '4333.00'           │ '230104 ± 0.02%'           │ '230787'                  │ 226523  │
│ 1       │ 'v1 (set)'      │ '3641.63 ± 0.16%'    │ '3583.00'           │ '276968 ± 0.01%'           │ '279096'                  │ 274602  │
└─────────┴─────────────────┴──────────────────────┴─────────────────────┴────────────────────────────┴───────────────────────────┴─────────┘
```